### PR TITLE
重构inferRawType函数

### DIFF
--- a/src/IDE/convertor-idea/src/main/java/com/huawei/hms/convertor/idea/spi/CodeConvertServiceImpl.java
+++ b/src/IDE/convertor-idea/src/main/java/com/huawei/hms/convertor/idea/spi/CodeConvertServiceImpl.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class CodeConvertServiceImpl implements CodeConvertService {
 
-    public Map<String, Project> projectMap = new HashMap<>();
+    private Map<String, Project> projectMap = new HashMap<>();
 
     @Override
     public Result convert(String projectPath, ConversionItem conversionItem) {

--- a/src/SourceCodeTransformer/build.gradle
+++ b/src/SourceCodeTransformer/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     }
     compile 'com.ibm.icu:icu4j:64.2'
     compile 'org.json:json:20190722'
+    testCompile('junit:junit:4.12')
 }
 
 jar {

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -65,8 +65,12 @@ public class InferRawTypeHelper {
         map.put("linkedSetOf", KotlinBasicType.LINKED_HASH_SET);
         map.put("mutableSetOf", KotlinBasicType.MUTABLE_SET);
         map.put("sortedSetOf", KotlinBasicType.TREE_SET);
-
     }
 
+    private InferRawTypeHelper() {
+    }
 
+    public KotlinBasicType getRawType(String funcName) {
+        return map.getOrDefault(funcName, null);
+    }
 }

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -59,7 +59,12 @@ public class InferRawTypeHelper {
         map.put("mutableMapOf", KotlinBasicType.MUTABLE_MAP);
         map.put("sortedMapOf", KotlinBasicType.SORTED_MAP);
 
-
+        map.put("Set", KotlinBasicType.SET);
+        map.put("setOf", KotlinBasicType.SET);
+        map.put("hashSetOf", KotlinBasicType.HASH_SET);
+        map.put("linkedSetOf", KotlinBasicType.LINKED_HASH_SET);
+        map.put("mutableSetOf", KotlinBasicType.MUTABLE_SET);
+        map.put("sortedSetOf", KotlinBasicType.TREE_SET);
 
     }
 

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * @since 2021-09-23
  */
 public class InferRawTypeHelper {
-    private static Map<String, KotlinBasicType> map = new HashMap<>();
+    private static final Map<String, KotlinBasicType> map = new HashMap<>();
 
     static {
         map.put("Array", KotlinBasicType.ARRAY);

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -70,7 +70,7 @@ public class InferRawTypeHelper {
     private InferRawTypeHelper() {
     }
 
-    public KotlinBasicType getRawType(String funcName) {
+    public static KotlinBasicType getRawType(String funcName) {
         return map.getOrDefault(funcName, null);
     }
 }

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021. Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.huawei.codebot.analyzer.x2y.global.kotlin;
+
+import com.huawei.codebot.analyzer.x2y.global.KotlinBasicType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InferRawTypeHelper {
+
+
+
+}

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -44,6 +44,11 @@ public class InferRawTypeHelper {
         map.put("longArrayOf", KotlinBasicType.LONG_ARRAY);
         map.put("shortArrayOf", KotlinBasicType.SHORT_ARRAY);
 
+        map.put("List", KotlinBasicType.LIST);
+        map.put("listOf", KotlinBasicType.LIST);
+        map.put("listOfNotNull", KotlinBasicType.LIST);
+        map.put("emptyList", KotlinBasicType.LIST);
+
 
     }
 

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -20,8 +20,23 @@ import com.huawei.codebot.analyzer.x2y.global.KotlinBasicType;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * InferRawTypeHelper,
+ * inferRawType kotlinBasicType mapping
+ *
+ * @since 2021-09-23
+ */
 public class InferRawTypeHelper {
+    private static Map<String, KotlinBasicType> map = new HashMap<>();
 
+    static {
+        map.put("Array", KotlinBasicType.ARRAY);
+        map.put("arrayOf", KotlinBasicType.ARRAY);
+        map.put("arrayOfNulls", KotlinBasicType.ARRAY);
+        map.put("emptyArray", KotlinBasicType.ARRAY);
+
+
+    }
 
 
 }

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -52,6 +52,10 @@ public class InferRawTypeHelper {
         map.put("arrayListOf", KotlinBasicType.ARRAY_LIST);
         map.put("mutableListOf", KotlinBasicType.MUTABLE_LIST);
 
+        map.put("Map", KotlinBasicType.MAP);
+        map.put("mapOf", KotlinBasicType.MAP);
+
+
 
     }
 

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -54,6 +54,10 @@ public class InferRawTypeHelper {
 
         map.put("Map", KotlinBasicType.MAP);
         map.put("mapOf", KotlinBasicType.MAP);
+        map.put("hashMapOf", KotlinBasicType.HASH_MAP);
+        map.put("linkedMapOf", KotlinBasicType.LINKED_HASH_MAP);
+        map.put("mutableMapOf", KotlinBasicType.MUTABLE_MAP);
+        map.put("sortedMapOf", KotlinBasicType.SORTED_MAP);
 
 
 

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -49,6 +49,9 @@ public class InferRawTypeHelper {
         map.put("listOfNotNull", KotlinBasicType.LIST);
         map.put("emptyList", KotlinBasicType.LIST);
 
+        map.put("arrayListOf", KotlinBasicType.ARRAY_LIST);
+        map.put("mutableListOf", KotlinBasicType.MUTABLE_LIST);
+
 
     }
 

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelper.java
@@ -35,6 +35,15 @@ public class InferRawTypeHelper {
         map.put("arrayOfNulls", KotlinBasicType.ARRAY);
         map.put("emptyArray", KotlinBasicType.ARRAY);
 
+        map.put("booleanArrayOf", KotlinBasicType.BOOLEAN_ARRAY);
+        map.put("byteArrayOf", KotlinBasicType.BYTE_ARRAY);
+        map.put("charArrayOf", KotlinBasicType.CHAR_ARRAY);
+        map.put("doubleArrayOf", KotlinBasicType.DOUBLE_ARRAY);
+        map.put("floatArrayOf", KotlinBasicType.FLOAT_ARRAY);
+        map.put("intArrayOf", KotlinBasicType.INT_ARRAY);
+        map.put("longArrayOf", KotlinBasicType.LONG_ARRAY);
+        map.put("shortArrayOf", KotlinBasicType.SHORT_ARRAY);
+
 
     }
 

--- a/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/KotlinTypeInferencer.java
+++ b/src/SourceCodeTransformer/src/main/java/com/huawei/codebot/analyzer/x2y/global/kotlin/KotlinTypeInferencer.java
@@ -636,62 +636,8 @@ public class KotlinTypeInferencer extends TypeInferencer {
     }
 
     private String inferRawType(String funcName) {
-        switch (funcName) {
-            case "Array":
-            case "arrayOf":
-            case "arrayOfNulls":
-            case "emptyArray":
-                return KotlinBasicType.ARRAY.getQualifiedName();
-            case "booleanArrayOf":
-                return KotlinBasicType.BOOLEAN_ARRAY.getQualifiedName();
-            case "byteArrayOf":
-                return KotlinBasicType.BYTE_ARRAY.getQualifiedName();
-            case "charArrayOf":
-                return KotlinBasicType.CHAR_ARRAY.getQualifiedName();
-            case "doubleArrayOf":
-                return KotlinBasicType.DOUBLE_ARRAY.getQualifiedName();
-            case "floatArrayOf":
-                return KotlinBasicType.FLOAT_ARRAY.getQualifiedName();
-            case "intArrayOf":
-                return KotlinBasicType.INT_ARRAY.getQualifiedName();
-            case "longArrayOf":
-                return KotlinBasicType.LONG_ARRAY.getQualifiedName();
-            case "shortArrayOf":
-                return KotlinBasicType.SHORT_ARRAY.getQualifiedName();
-            case "List":
-            case "listOf":
-            case "listOfNotNull":
-            case "emptyList":
-                return KotlinBasicType.LIST.getQualifiedName();
-            case "arrayListOf":
-                return KotlinBasicType.ARRAY_LIST.getQualifiedName();
-            case "mutableListOf":
-                return KotlinBasicType.MUTABLE_LIST.getQualifiedName();
-            case "Map":
-            case "mapOf":
-                return KotlinBasicType.MAP.getQualifiedName();
-            case "hashMapOf":
-                return KotlinBasicType.HASH_MAP.getQualifiedName();
-            case "linkedMapOf":
-                return KotlinBasicType.LINKED_HASH_MAP.getQualifiedName();
-            case "mutableMapOf":
-                return KotlinBasicType.MUTABLE_MAP.getQualifiedName();
-            case "sortedMapOf":
-                return KotlinBasicType.SORTED_MAP.getQualifiedName();
-            case "Set":
-            case "setOf":
-                return KotlinBasicType.SET.getQualifiedName();
-            case "hashSetOf":
-                return KotlinBasicType.HASH_SET.getQualifiedName();
-            case "linkedSetOf":
-                return KotlinBasicType.LINKED_HASH_SET.getQualifiedName();
-            case "mutableSetOf":
-                return KotlinBasicType.MUTABLE_SET.getQualifiedName();
-            case "sortedSetOf":
-                return KotlinBasicType.TREE_SET.getQualifiedName();
-            default:
-                return null;
-        }
+        KotlinBasicType rawType = InferRawTypeHelper.getRawType(funcName);
+        return rawType == null ? null : rawType.getQualifiedName();
     }
 
     private TypeInfo uniformType(List<TypeInfo> typeInfos) {

--- a/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
+++ b/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
@@ -52,8 +52,20 @@ public class InferRawTypeHelperTest {
         Assert.assertEquals(inferRawType("linkedSetOf"), InferRawTypeHelper.getRawType("linkedSetOf").getQualifiedName());
         Assert.assertEquals(inferRawType("mutableSetOf"), InferRawTypeHelper.getRawType("mutableSetOf").getQualifiedName());
         Assert.assertEquals(inferRawType("sortedSetOf"), InferRawTypeHelper.getRawType("sortedSetOf").getQualifiedName());
+    }
 
+    @org.junit.Test
+    public void getRawType_null() {
+        Assert.assertNull(inferRawType(""));
+        Assert.assertNull(InferRawTypeHelper.getRawType(""));
 
+        Assert.assertNull(inferRawType("1"));
+        Assert.assertNull(InferRawTypeHelper.getRawType("1"));
+        Assert.assertNull(InferRawTypeHelper.getRawType(null));
+
+        Assert.assertNull(inferRawType("2"));
+        Assert.assertNull(InferRawTypeHelper.getRawType("2"));
+        Assert.assertNull(InferRawTypeHelper.getRawType(null));
     }
 
     private String inferRawType(String funcName) {

--- a/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
+++ b/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021. Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.huawei.codebot.analyzer.x2y.global.kotlin;
+
+public class InferRawTypeHelperTest {
+
+
+    @org.junit.Test
+    public void getRawType() {
+
+
+    }
+}

--- a/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
+++ b/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
@@ -16,12 +16,42 @@
 package com.huawei.codebot.analyzer.x2y.global.kotlin;
 
 import com.huawei.codebot.analyzer.x2y.global.KotlinBasicType;
+import org.junit.Assert;
 
 public class InferRawTypeHelperTest {
 
-
     @org.junit.Test
     public void getRawType() {
+        Assert.assertEquals(inferRawType("Array"), InferRawTypeHelper.getRawType("Array").getQualifiedName());
+        Assert.assertEquals(inferRawType("arrayOf"), InferRawTypeHelper.getRawType("arrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("arrayOfNulls"), InferRawTypeHelper.getRawType("arrayOfNulls").getQualifiedName());
+        Assert.assertEquals(inferRawType("emptyArray"), InferRawTypeHelper.getRawType("emptyArray").getQualifiedName());
+        Assert.assertEquals(inferRawType("booleanArrayOf"), InferRawTypeHelper.getRawType("booleanArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("byteArrayOf"), InferRawTypeHelper.getRawType("byteArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("charArrayOf"), InferRawTypeHelper.getRawType("charArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("doubleArrayOf"), InferRawTypeHelper.getRawType("doubleArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("floatArrayOf"), InferRawTypeHelper.getRawType("floatArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("intArrayOf"), InferRawTypeHelper.getRawType("intArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("longArrayOf"), InferRawTypeHelper.getRawType("longArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("shortArrayOf"), InferRawTypeHelper.getRawType("shortArrayOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("List"), InferRawTypeHelper.getRawType("List").getQualifiedName());
+        Assert.assertEquals(inferRawType("listOf"), InferRawTypeHelper.getRawType("listOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("listOfNotNull"), InferRawTypeHelper.getRawType("listOfNotNull").getQualifiedName());
+        Assert.assertEquals(inferRawType("emptyList"), InferRawTypeHelper.getRawType("emptyList").getQualifiedName());
+        Assert.assertEquals(inferRawType("arrayListOf"), InferRawTypeHelper.getRawType("arrayListOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("mutableListOf"), InferRawTypeHelper.getRawType("mutableListOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("Map"), InferRawTypeHelper.getRawType("Map").getQualifiedName());
+        Assert.assertEquals(inferRawType("mapOf"), InferRawTypeHelper.getRawType("mapOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("hashMapOf"), InferRawTypeHelper.getRawType("hashMapOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("linkedMapOf"), InferRawTypeHelper.getRawType("linkedMapOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("mutableMapOf"), InferRawTypeHelper.getRawType("mutableMapOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("sortedMapOf"), InferRawTypeHelper.getRawType("sortedMapOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("Set"), InferRawTypeHelper.getRawType("Set").getQualifiedName());
+        Assert.assertEquals(inferRawType("setOf"), InferRawTypeHelper.getRawType("setOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("hashSetOf"), InferRawTypeHelper.getRawType("hashSetOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("linkedSetOf"), InferRawTypeHelper.getRawType("linkedSetOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("mutableSetOf"), InferRawTypeHelper.getRawType("mutableSetOf").getQualifiedName());
+        Assert.assertEquals(inferRawType("sortedSetOf"), InferRawTypeHelper.getRawType("sortedSetOf").getQualifiedName());
 
 
     }

--- a/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
+++ b/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
@@ -18,6 +18,11 @@ package com.huawei.codebot.analyzer.x2y.global.kotlin;
 import com.huawei.codebot.analyzer.x2y.global.KotlinBasicType;
 import org.junit.Assert;
 
+/**
+ * InferRawTypeHelper Test
+ *
+ * @since 2021-09-23
+ */
 public class InferRawTypeHelperTest {
 
     @org.junit.Test

--- a/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
+++ b/src/SourceCodeTransformer/src/test/java/com/huawei/codebot/analyzer/x2y/global/kotlin/InferRawTypeHelperTest.java
@@ -15,6 +15,8 @@
  */
 package com.huawei.codebot.analyzer.x2y.global.kotlin;
 
+import com.huawei.codebot.analyzer.x2y.global.KotlinBasicType;
+
 public class InferRawTypeHelperTest {
 
 
@@ -22,5 +24,64 @@ public class InferRawTypeHelperTest {
     public void getRawType() {
 
 
+    }
+
+    private String inferRawType(String funcName) {
+        switch (funcName) {
+            case "Array":
+            case "arrayOf":
+            case "arrayOfNulls":
+            case "emptyArray":
+                return KotlinBasicType.ARRAY.getQualifiedName();
+            case "booleanArrayOf":
+                return KotlinBasicType.BOOLEAN_ARRAY.getQualifiedName();
+            case "byteArrayOf":
+                return KotlinBasicType.BYTE_ARRAY.getQualifiedName();
+            case "charArrayOf":
+                return KotlinBasicType.CHAR_ARRAY.getQualifiedName();
+            case "doubleArrayOf":
+                return KotlinBasicType.DOUBLE_ARRAY.getQualifiedName();
+            case "floatArrayOf":
+                return KotlinBasicType.FLOAT_ARRAY.getQualifiedName();
+            case "intArrayOf":
+                return KotlinBasicType.INT_ARRAY.getQualifiedName();
+            case "longArrayOf":
+                return KotlinBasicType.LONG_ARRAY.getQualifiedName();
+            case "shortArrayOf":
+                return KotlinBasicType.SHORT_ARRAY.getQualifiedName();
+            case "List":
+            case "listOf":
+            case "listOfNotNull":
+            case "emptyList":
+                return KotlinBasicType.LIST.getQualifiedName();
+            case "arrayListOf":
+                return KotlinBasicType.ARRAY_LIST.getQualifiedName();
+            case "mutableListOf":
+                return KotlinBasicType.MUTABLE_LIST.getQualifiedName();
+            case "Map":
+            case "mapOf":
+                return KotlinBasicType.MAP.getQualifiedName();
+            case "hashMapOf":
+                return KotlinBasicType.HASH_MAP.getQualifiedName();
+            case "linkedMapOf":
+                return KotlinBasicType.LINKED_HASH_MAP.getQualifiedName();
+            case "mutableMapOf":
+                return KotlinBasicType.MUTABLE_MAP.getQualifiedName();
+            case "sortedMapOf":
+                return KotlinBasicType.SORTED_MAP.getQualifiedName();
+            case "Set":
+            case "setOf":
+                return KotlinBasicType.SET.getQualifiedName();
+            case "hashSetOf":
+                return KotlinBasicType.HASH_SET.getQualifiedName();
+            case "linkedSetOf":
+                return KotlinBasicType.LINKED_HASH_SET.getQualifiedName();
+            case "mutableSetOf":
+                return KotlinBasicType.MUTABLE_SET.getQualifiedName();
+            case "sortedSetOf":
+                return KotlinBasicType.TREE_SET.getQualifiedName();
+            default:
+                return null;
+        }
     }
 }


### PR DESCRIPTION
inferRawType函数的主逻辑被InferRawTypeHelper纳管，既增加了后续扩展性，又能有效降低inferRawType圈复杂度